### PR TITLE
4419 is electronic only

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ write_1099_file(ascii_string, output_path)
 # Access via IRS FIRE System
 A few things need to happen before you can submit an output file to the IRS:
 
-* You need a *Transmitter Control Code* or "TCC." To get one, you unfortunately have to mail or fax [this form](https://www.irs.gov/pub/irs-pdf/f4419.pdf). It can take a couple weeks to get a response.
+* You need a *Transmitter Control Code* or "TCC." This is done by filing From 4419 electronically (https://fire.irs.gov). It can take 45 days to get a response.
 * You need to have a valid business tax identification code (EIN/TIN). This will be linked to your TCC, and is what you'll use for the "transmitter" record in your FIRE submissions.
 
 # Future Work


### PR DESCRIPTION
See here: https://www.irs.gov/e-file-providers/filing-information-returns-electronically-fire

> 
> Alert (posted September 27, 2019)
> Mandate to electronically file Form 4419, Application for Filing Information Returns Electronically (FIRE)
> 
> As of October 1, 2019, Form 4419 is mandated to be electronically filed when requesting an original TCC. Submit an online Fill-in Form 4419 located within the FIRE System at https://fire.irs.gov/
> 
> Only submit a paper Form 4419 (Rev. 9-2019) when you have an existing Transmitter Control Code (TCC) to:
> 
> Revise current TCC information.
> Request an additional TCC for form type listed on Form 4419 Block 8.