### PR TITLE
Updating to 1099 format for tax year 2021 (as per Pub 1220)

### DIFF
--- a/fire/entities/payees.py
+++ b/fire/entities/payees.py
@@ -32,15 +32,16 @@ _ITEMS = [
 ]
 
 for field in chain((x for x in range(1, 10)), \
-                   (chr(x) for x in range(ord('A'), ord('H')))):
+                   (chr(x) for x in range(ord('A'), ord('I'))), \
+                   'J'):
     _ITEMS.append((f"payment_amount_{field}",
                    ("000000000000", 12, "\x00", lambda x: rjust_zero(x, 12))))
 
 _ITEMS += [
+    ("blank_2", ("", 16, "\x00", lambda x: x)),
     ("foreign_country_indicator", ("", 1, "\x00", lambda x: x)),
     ("first_payee_name_line", ("", 40, "\x00", uppercase)),
     ("second_payee_name_line", ("", 40, "\x00", uppercase)),
-    ("blank_2", ("", 40, "\x00", lambda x: x)),
     ("payee_mailing_address", ("", 40, "\x00", lambda x: x)),
     ("blank_3", ("", 40, "\x00", lambda x: x)),
     ("payee_city", ("", 40, "\x00", lambda x: x)),

--- a/fire/schema/1099_NEC_schema.json
+++ b/fire/schema/1099_NEC_schema.json
@@ -84,7 +84,6 @@
                     "payers_account_number_for_payee": {"type": "string", "maxLength": 20},
                     "payers_office_code": {"type": "string", "maxLength": 4},
                     "payment_amount_1": {"$ref": "#/definitions/dollar_amount"},
-                    "payment_amount_4": {"$ref": "#/definitions/dollar_amount"},
                     "foreign_country_indicator": {"type": "string", "maxLength": 1},
                     "first_payee_name_line": {"$ref": "#/definitions/generic_name"},
                     "second_payee_name_line": {"$ref": "#/definitions/generic_name"},
@@ -95,8 +94,6 @@
                     "record_sequence_number": {"type": "string", "maxLength": 8},
                     "second_tin_notice": {"type": "string", "maxLength": 1},
                     "direct_sales_indicator": {"type": "string", "maxLength": 1},
-                    "fatca_filing_requirement_indicator": {"type": "string", "maxLength": 1},
-                    "special_data_entries": {"type": "string", "maxLength": 60},
                     "state_income_tax_withheld": {"type": "string", "maxLength": 12},
                     "local_income_tax_withheld": {"type": "string", "maxLength": 12},
                     "combined_federal_state_code": {"type": "string", "maxLength": 2}
@@ -114,7 +111,6 @@
                 "record_type": {"type": "string", "maxLength": 1},
                 "number_of_payees": {"type": "string", "maxLength": 8},
                 "payment_amount_1": {"$ref": "#/definitions/dollar_amount"},
-                "payment_amount_4": {"$ref": "#/definitions/dollar_amount"},
                 "record_sequence_number": {"type": "string", "maxLength": 8}
             }
         },
@@ -163,7 +159,7 @@
             "pattern":"^[0-9]{4}",
             "maxLength": 4
         },
-       "generic_name":{
+        "generic_name":{
             "type": "string",
             "maxLength": 40
         },

--- a/fire/translator/translator.py
+++ b/fire/translator/translator.py
@@ -222,6 +222,8 @@ def insert_payer_totals(data):
         "E",
         "F",
         "G",
+        "H",
+        "J"
     ]
     totals = [0 for _ in range(len(codes))]
     payer_code_string = ""


### PR DESCRIPTION
Specifically updating the payment fields in the 'B' record to 18 (0-9, A-H, J), as per the latest Pub 1220 (https://www.irs.gov/pub/irs-pdf/p1220.pdf).