### PR TITLE
Add combined federal state records

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ A few things need to happen before you can submit an output file to the IRS:
 * You need a *Transmitter Control Code* or "TCC." This is done by filing From 4419 electronically (https://fire.irs.gov). It can take 45 days to get a response.
 * You need to have a valid business tax identification code (EIN/TIN). This will be linked to your TCC, and is what you'll use for the "transmitter" record in your FIRE submissions.
 
+# Running tests
+
+To run this module's tests, `pip install nose` and then invoke nosetests.
+```bash
+$  nosetests spec/test*.py
+```
+
 # Future Work
 * Add support for "Extension of Time" requests
 * Add support for filings other than 1099-MISC and 1099-NEC

--- a/fire/entities/end_of_payer.py
+++ b/fire/entities/end_of_payer.py
@@ -33,7 +33,7 @@ _ITEMS += [
     ("blank_2", ("", 160, "\x00", lambda x: x)),
     ("record_sequence_number", ("", 8, "0", lambda x: x)),
     ("blank_3", ("", 241, "\x00", lambda x: x)),
-    ("blank_4", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_4", ("\x0a\x0a", 2, "\x00", lambda x: x))
 ]
 
 _END_OF_PAYER_SORT, _END_OF_PAYER_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/end_of_transmission.py
+++ b/fire/entities/end_of_transmission.py
@@ -25,7 +25,7 @@ _ITEMS = [
     ("blank_2", ("", 442, "\x00", lambda x: x)),
     ("record_sequence_number", ("", 8, "0", lambda x: x)),
     ("blank_3", ("", 241, "\x00", lambda x: x)),
-    ("blank_4", ("", 2, "\x00", lambda x: x))
+    ("blank_4", ("\r\n", 2, "\x00", lambda x: x))
 ]
 
 _END_OF_TRANSMISSION_SORT, _END_OF_TRANSMISSION_TRANSFORMS = \

--- a/fire/entities/end_of_transmission.py
+++ b/fire/entities/end_of_transmission.py
@@ -25,7 +25,7 @@ _ITEMS = [
     ("blank_2", ("", 442, "\x00", lambda x: x)),
     ("record_sequence_number", ("", 8, "0", lambda x: x)),
     ("blank_3", ("", 241, "\x00", lambda x: x)),
-    ("blank_4", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_4", ("\x0a\x0a", 2, "\x00", lambda x: x))
 ]
 
 _END_OF_TRANSMISSION_SORT, _END_OF_TRANSMISSION_TRANSFORMS = \

--- a/fire/entities/extension_of_time.py
+++ b/fire/entities/extension_of_time.py
@@ -27,7 +27,7 @@ _ITEMS = [
     ("document_indicator", ("A", 1, "\x00", lambda x: x)),
     ("foreign_entity_indicator", ("", 1, "\x00", lambda x: x)),
     ("blank_1", ("", 11, "\x00", lambda x: x)),
-    ("blank_2", ("", 2, "\x00", lambda x: x))
+    ("blank_2", ("\r\n", 2, "\x00", lambda x: x))
 ]
 
 _EXTENSION_OF_TIME_SORT, _EXTENSION_OF_TIME_TRANSFORMS = \

--- a/fire/entities/extension_of_time.py
+++ b/fire/entities/extension_of_time.py
@@ -27,7 +27,7 @@ _ITEMS = [
     ("document_indicator", ("A", 1, "\x00", lambda x: x)),
     ("foreign_entity_indicator", ("", 1, "\x00", lambda x: x)),
     ("blank_1", ("", 11, "\x00", lambda x: x)),
-    ("blank_2", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_2", ("\x0a\x0a", 2, "\x00", lambda x: x))
 ]
 
 _EXTENSION_OF_TIME_SORT, _EXTENSION_OF_TIME_TRANSFORMS = \

--- a/fire/entities/payees.py
+++ b/fire/entities/payees.py
@@ -60,7 +60,7 @@ _ITEMS += [
     ("state_income_tax_withheld", ("", 12, "\x00", lambda x: x)),
     ("local_income_tax_withheld", ("", 12, "\x00", lambda x: x)),
     ("combined_federal_state_code", ("", 2, "\x00", lambda x: x)),
-    ("blank_8", ("", 2, "\x00", lambda x: x))
+    ("blank_8", ("\r\n", 2, "\x00", lambda x: x))
 ]
 
 _PAYEE_SORT, _PAYEE_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/payees.py
+++ b/fire/entities/payees.py
@@ -60,7 +60,7 @@ _ITEMS += [
     ("state_income_tax_withheld", ("", 12, "\x00", lambda x: x)),
     ("local_income_tax_withheld", ("", 12, "\x00", lambda x: x)),
     ("combined_federal_state_code", ("", 2, "\x00", lambda x: x)),
-    ("blank_8", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_8", ("\x0a\x0a", 2, "\x00", lambda x: x))
 ]
 
 _PAYEE_SORT, _PAYEE_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/payer.py
+++ b/fire/entities/payer.py
@@ -39,7 +39,7 @@ _ITEMS = [
     ("record_sequence_number",
      ("00000002", 8, "\x00", lambda x: rjust_zero(x, 8))),
     ("blank_4", ("", 241, "\x00", lambda x: x)),
-    ("blank_5", ("", 2, "\x00", lambda x: x))
+    ("blank_5", ("\r\n", 2, "\x00", lambda x: x))
 ]
 
 _PAYER_SORT, _PAYER_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/payer.py
+++ b/fire/entities/payer.py
@@ -39,7 +39,7 @@ _ITEMS = [
     ("record_sequence_number",
      ("00000002", 8, "\x00", lambda x: rjust_zero(x, 8))),
     ("blank_4", ("", 241, "\x00", lambda x: x)),
-    ("blank_5", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_5", ("\x0a\x0a", 2, "\x0a", lambda x: x))
 ]
 
 _PAYER_SORT, _PAYER_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/state_totals.py
+++ b/fire/entities/state_totals.py
@@ -37,7 +37,7 @@ _ITEMS += [
     ("local_income_tax_withheld_total", ("", 18, "\x00", lambda x: x)),
     ("blank_4", ("", 4, "\x00", lambda x: x)),
     ("combined_federal_state_code", ("", 2, "\x00", lambda x: x)),
-    ("blank_5", ("\r\n", 2, "\x00", lambda x: x)),
+    ("blank_5", ("\x0a\x0a", 2, "\x0a", lambda x: x)),
 ]
 
 _STATE_TOTALS_SORT, _STATE_TOTALS_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/state_totals.py
+++ b/fire/entities/state_totals.py
@@ -1,6 +1,6 @@
 """
-Module: entities.end_of_payer
-Representation of an "end_of_payer" record, including transformation functions
+Module: entities.state_totals
+Representation of an "state totals" record, including transformation functions
 and support functions for conversion into different formats.
 """
 from itertools import chain
@@ -9,16 +9,16 @@ from fire.translator.util import rjust_zero
 from fire.translator.util import factor_transforms, xform_entity, fire_entity
 
 """
-_END_OF_PAYER_TRANSFORMS
+_END_OF_STATE_TOTALS_TRANSFORMS
 -----------------------
-Stores metadata associated with each field in a Transmitter record.
+Stores metadata associated with each field in a state_totals record.
 Values in key-value pairs represent metadata in the following format:
 
 (default value, length, fill character, transformation function)
 """
 
 _ITEMS = [
-    ("record_type", ("C", 1, "\x00", lambda x: x)),
+    ("record_type", ("K", 1, "\x00", lambda x: x)),
     ("number_of_payees", ("", 8, "0", lambda x: x)),
     ("blank_1", ("", 6, "\x00", lambda x: x)),
 ]
@@ -26,21 +26,25 @@ _ITEMS = [
 for field in chain((x for x in range(1, 10)), \
                    (chr(x) for x in range(ord('A'), ord('I'))), \
                    'J'):
-    _ITEMS.append((f"payment_amount_{field}",
+    _ITEMS.append((f"control_total_{field}",
                    (18*"0", 18, "0", lambda x: rjust_zero(x, 18))))
 
 _ITEMS += [
     ("blank_2", ("", 160, "\x00", lambda x: x)),
     ("record_sequence_number", ("", 8, "0", lambda x: x)),
-    ("blank_3", ("", 241, "\x00", lambda x: x)),
-    ("blank_4", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_3", ("", 199, "\x00", lambda x: x)),
+    ("state_income_tax_withheld_total", ("", 18, "\x00", lambda x: x)),
+    ("local_income_tax_withheld_total", ("", 18, "\x00", lambda x: x)),
+    ("blank_4", ("", 4, "\x00", lambda x: x)),
+    ("combined_federal_state_code", ("", 2, "\x00", lambda x: x)),
+    ("blank_5", ("\r\n", 2, "\x00", lambda x: x)),
 ]
 
-_END_OF_PAYER_SORT, _END_OF_PAYER_TRANSFORMS = factor_transforms(_ITEMS)
+_STATE_TOTALS_SORT, _STATE_TOTALS_TRANSFORMS = factor_transforms(_ITEMS)
 
 def xform(data):
     """
-    Applies transformation functions definted in _END_OF_PAYER_TRANSFORMS to
+    Applies transformation functions definted in _END_OF_STATE_TOTALS_TRANSFORMS to
     data supplied as parameter to respective key-value pairs provided as the
     input parameter.
 
@@ -48,7 +52,7 @@ def xform(data):
     ----------
     data : dict
         Expects data parameter to have keys that exist in the
-        _END_OF_PAYER_TRANSFORMS dict.
+        _END_OF_STATE_TOTALS_TRANSFORMS dict.
 
     Returns
     ----------
@@ -56,22 +60,26 @@ def xform(data):
         Dictionary containing processed (transformed) data provided as a
         parameter.
     """
-    return xform_entity(_END_OF_PAYER_TRANSFORMS, data)
+    return xform_entity(_STATE_TOTALS_TRANSFORMS, data)
 
 def fire(data):
     """
-    Returns the given record as a string formatted to the IRS Publication 1220
+    Returns the given records as a string formatted to the IRS Publication 1220
     specification, based on data supplied as parameter.
 
     Parameters
     ----------
-    data : dict
+    data : list of dict
         Expects data parameter to have all keys specified in
-        _END_OF_PAYER_TRANSFORMS.
+        _END_OF_STATE_TOTALS_TRANSFORMS.
 
     Returns
     ----------
     str
         String formatted to meet IRS Publication 1220
     """
-    return fire_entity(_END_OF_PAYER_TRANSFORMS, _END_OF_PAYER_SORT, data)
+    return ''.join([
+        fire_entity(_STATE_TOTALS_TRANSFORMS, _STATE_TOTALS_SORT, state)
+        for state in data
+    ])
+    return fire_entity(_END_OF_STATE_TOTALS_TRANSFORMS, _END_OF_STATE_TOTALS_SORT, data)

--- a/fire/entities/transmitter.py
+++ b/fire/entities/transmitter.py
@@ -55,7 +55,7 @@ _ITEMS = [
     ("blank_5", ("", 35, "\x00", lambda x: x)),
     ("vendor_foreign_entity_indicator", ("", 1, "\x00", uppercase)),
     ("blank_6", ("", 8, "\x00", lambda x: x)),
-    ("blank_7", ("", 2, "\x00", lambda x: x))
+    ("blank_7", ("\r\n", 2, "\x00", lambda x: x))
 ]
 
 _TRANSMITTER_SORT, _TRANSMITTER_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/entities/transmitter.py
+++ b/fire/entities/transmitter.py
@@ -55,7 +55,7 @@ _ITEMS = [
     ("blank_5", ("", 35, "\x00", lambda x: x)),
     ("vendor_foreign_entity_indicator", ("", 1, "\x00", uppercase)),
     ("blank_6", ("", 8, "\x00", lambda x: x)),
-    ("blank_7", ("\r\n", 2, "\x00", lambda x: x))
+    ("blank_7", ("\x0a\x0a", 2, "\x0a", lambda x: x))
 ]
 
 _TRANSMITTER_SORT, _TRANSMITTER_TRANSFORMS = factor_transforms(_ITEMS)

--- a/fire/schema/base_schema.json
+++ b/fire/schema/base_schema.json
@@ -146,6 +146,35 @@
                 "record_sequence_number": {"type": "string", "maxLength": 8}
             } 
         },
+        "state_totals":{
+            "type": "object",
+            "properties": {
+                "record_type": {"type": "string", "maxLength": 1},
+                "number_of_payees": {"type": "string", "maxLength": 8},
+                "control_total_1": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_2": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_3": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_4": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_5": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_6": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_7": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_8": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_9": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_A": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_B": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_C": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_D": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_E": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_F": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_G": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_H": {"$ref": "#/definitions/dollar_amount"},
+                "control_total_J": {"$ref": "#/definitions/dollar_amount"},
+                "record_sequence_number": {"type": "string", "maxLength": 8},
+                "state_income_tax_withheld_total": {"type": "string", "maxLength": 12},
+                "local_income_tax_withheld_total": {"type": "string", "maxLength": 12},
+                "combined_federal_state_code": {"type": "string", "maxLength": 2}
+            }
+        },
         "end_of_transmission":{
             "type": "object",
             "properties":{

--- a/fire/translator/translator.py
+++ b/fire/translator/translator.py
@@ -201,7 +201,6 @@ def insert_state_total_records(data):
         }))
 
 
-
 def insert_sequence_numbers(data):
     """
     Inserts sequence numbers into each record, in the following order:
@@ -307,7 +306,7 @@ def insert_payer_totals(data):
         sd = by_state[state_code]
         st_data["number_of_payees"] = f"{sd['number_of_payees']:0>8}"
         for code in codes:
-            st_data["control_total_" + code] = f"{sd[code]:0>12}"
+            st_data["control_total_" + code] = f"{sd[code]:0>18}"
         for wh in wh_codes:
             st_data[wh] = f"{sd[code]:0>18}"
 

--- a/spec/spec_util.py
+++ b/spec/spec_util.py
@@ -12,9 +12,10 @@ import jsonschema
 
 from jsonschema import validate
 from nose.tools import raises
+import re
 
 SCHEMA = json.load(open("./fire/schema/base_schema.json"))
-VALID_ALL_PATH = "./spec/data/valid_all.json"
+VALID_ALL_PATH = "./spec/data/valid_all_MISC.json"
 INVALID_PHONE_NUMS = ["+1 555 666 7777", "555 A44 B777", "123ABC5678",
                       "123 45 67", "555 666 777788", "555 666 7777 #"]
 VALID_PHONE_NUMS = ["5556667777", "555-666-7777", "(555)666-7777",
@@ -117,7 +118,7 @@ def dive_to_path(full_dictionary, path, value):
     return _dive_recursion(dict_copy, path, value)
 
 def check_blanks(sub_string):
-    assert sub_string == len(sub_string)*"\x00"
+    assert re.fullmatch(r'[\x00\x0a\x0d]*', sub_string)
 
 @raises(jsonschema.exceptions.ValidationError)
 def check_value_too_long(dict_obj, path, value):

--- a/spec/test_entity_payer.py
+++ b/spec/test_entity_payer.py
@@ -7,7 +7,7 @@ import jsonschema
 from jsonschema import validate
 from nose.tools import raises
 
-from spec_util import check_value_too_long, check_valid_phone_num, \
+from spec_util import check_blanks, check_value_too_long, check_valid_phone_num, \
                       check_invalid_phone_num, check_valid_tin, \
                       check_invalid_tin, check_valid_zip, check_invalid_zip, \
                       SCHEMA, PAYER_BLANK_MAP, VALID_ALL_DATA, \
@@ -122,5 +122,5 @@ def test_payer_fire_blanks_layout():
     for (offset_1_indexed, inclusive_bound) in PAYER_BLANK_MAP:
         yield check_blanks, test_string[(offset_1_indexed -1):inclusive_bound]
 
-def check_blanks(sub_string):
-    assert sub_string == len(sub_string)*"\x00"
+#def check_blanks(sub_string):
+#    assert sub_string == len(sub_string)*"\x00"

--- a/spec/test_entity_transmitter.py
+++ b/spec/test_entity_transmitter.py
@@ -7,7 +7,8 @@ import jsonschema
 from jsonschema import validate
 from nose.tools import raises
 
-from spec_util import check_value_too_long, check_valid_phone_num, \
+from spec_util import check_blanks, check_value_too_long, \
+                      check_valid_phone_num, \
                       check_invalid_phone_num, check_valid_tin, \
                       check_invalid_tin, check_valid_zip, check_invalid_zip, \
                       check_valid_email, check_invalid_email, \
@@ -139,6 +140,3 @@ def test_transmitter_fire_blanks_layout():
     test_string = transmitter.fire(transformed)
     for (offset_1_indexed, inclusive_bound) in TRANSMITTER_BLANK_MAP:
         yield check_blanks, test_string[(offset_1_indexed -1):inclusive_bound]
-
-def check_blanks(sub_string):
-    assert sub_string == len(sub_string)*"\x00"

--- a/spec/test_translator.py
+++ b/spec/test_translator.py
@@ -136,3 +136,19 @@ def test_translator_get_fire_format():
 
     for (offset, inclusive_bound) in END_OF_TRANSMISSION_BLANK_MAP:
         yield check_blanks, ascii_string[(offset + 749*5):inclusive_bound]
+
+def test_translator_insert_state_totals():
+    """A schema with a state / federal consolidated field should generate a state_totals record."""
+    data = translator.load_full_schema(VALID_ALL_DATA)
+    data["payees"][0]["combined_federal_state_code"] = "06"
+    translator.insert_state_total_records(data)
+
+    assert len(data["state_totals"]) == 1
+
+def test_insert_payer_totals():
+    data = translator.load_full_schema(VALID_ALL_DATA)
+    data["payees"][0]["combined_federal_state_code"] = "06"
+    data["payees"][1]["combined_federal_state_code"] = "06"
+    translator.insert_generated_values(data)
+    assert int(data["state_totals"][0]["control_total_1"]) == 1700
+

--- a/spec/test_translator.py
+++ b/spec/test_translator.py
@@ -80,7 +80,7 @@ def test_translator_insert_sequence_numbers():
         "00000006"
 
 
-# Tests whether payer and end_of_payer record fields are correctly isnerted
+# Tests whether payer and end_of_payer record fields are correctly inserted
 def test_translator_insert_payer_totals():
     # pylint: disable=invalid-sequence-index
     data = translator.load_full_schema(VALID_ALL_DATA)
@@ -93,7 +93,7 @@ def test_translator_insert_payer_totals():
     # Test end_of_payer record
     # pylint: disable=no-member
     values = [v for (k, v) in data["end_of_payer"].items() if \
-              re.match(r"^payment_amount_.", k)]
+              re.match(r"^payment_amount_.", k) and int(v) > 0]
     assert len(values) == 16
     for v in values:
         assert v == "000000000000001700"


### PR DESCRIPTION
Add support for combined federal & state filing.

This introduces the 'K' state_total records.
While we're here, make nose tests pass again, and change record separator to newlines to make it easier to examine.